### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: app
+      - name: Build
+        run: npm run build
+        working-directory: app
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./app/dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ npm run dev
 ```
 
 This will start the development server with hot module reloading.
+
+## GitHub Pages
+
+The project is configured to deploy automatically to GitHub Pages using the
+workflow in `.github/workflows/deploy.yml`. After pushing to the `main` branch
+on GitHub, the site will be available at:
+
+```
+https://<your-github-username>.github.io/Codex/
+```
+
+Replace `<your-github-username>` with your actual GitHub username.

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -4,4 +4,6 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Set base path for GitHub Pages deployment
+  base: '/Codex/',
 })


### PR DESCRIPTION
## Summary
- configure Vite base path for GitHub Pages
- add workflow to build and deploy to GitHub Pages
- document the GitHub Pages link in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840856f3da483248d7cc129e8ffc552